### PR TITLE
Sync CLI providers with current tool versions and align CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,31 +7,74 @@ on:
     branches: [master]
 
 jobs:
-  lint:
+  lint-and-test:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
-      - name: Install ruff
-        run: pip install ruff
-      - name: Ruff check
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Lint with ruff
         run: ruff check src/ tests/
-      - name: Ruff format check
+
+      - name: Check formatting with ruff
         run: ruff format --check src/ tests/
 
-  test:
+      - name: Type check with ty
+        run: ty check
+
+      - name: Run unit tests
+        run: python -m pytest tests/ -v --ignore=tests/integration
+
+  install-smoke-test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        variant:
+          - name: core
+            extras: ""
+            check: |
+              python -c "from agentabi import Session, run_sync, detect_agents; print('core import OK')"
+          - name: claude
+            extras: "[claude]"
+            check: |
+              python -c "from agentabi.providers.claude_sdk import ClaudeSDKProvider; print('claude SDK import OK')"
+          - name: codex
+            extras: "[codex]"
+            check: |
+              python -c "from agentabi.providers.codex_sdk import CodexSDKProvider; print('codex SDK import OK')"
+
+    name: smoke-test (${{ matrix.variant.name }})
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: pip install -e ".[dev]"
-      - name: Run tests
-        run: pytest tests/ -v --ignore=tests/integration
+          python-version: "3.11"
+
+      - name: Build wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --wheel
+
+      - name: Install from wheel in clean venv
+        run: |
+          python -m venv /tmp/smoke-venv
+          /tmp/smoke-venv/bin/pip install --upgrade pip
+          WHL=$(ls dist/*.whl)
+          /tmp/smoke-venv/bin/pip install "${WHL}${{ matrix.variant.extras }}"
+
+      - name: Smoke test imports
+        run: |
+          source /tmp/smoke-venv/bin/activate
+          ${{ matrix.variant.check }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,10 @@ dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
     "pytest-cov",
-    "ruff",
+    "ruff>=0.15.0",
+    "ty>=0.0.31",
+    "build>=1.2.2.post1",
+    "twine>=6.1.0",
 ]
 
 [project.urls]
@@ -80,7 +83,11 @@ line-length = 88
 target-version = "py39"
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "W"]
+select = ["E", "F", "I", "W", "UP", "C901"]
+ignore = ["UP007"]  # Allow Union[X, Y] syntax for Python 3.9 compat
+
+[tool.ruff.lint.mccabe]
+max-complexity = 15
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
@@ -94,7 +101,16 @@ markers = [
     "native_vs_sdk: Native vs SDK provider comparison tests",
 ]
 
-[tool.ty]
-# Optional SDK deps are not installed during type checking
+[tool.ty.environment]
+python-version = "3.9"
+
+[tool.ty.src]
+include = ["src", "tests"]
+
 [tool.ty.rules]
+# Optional SDK deps are not installed during type checking
 unresolved-import = "ignore"
+# ty cannot narrow Union[TypedDict, ...] members by discriminator key;
+# also SDK type stubs may lag behind actual API.
+invalid-key = "ignore"
+invalid-assignment = "ignore"

--- a/src/agentabi/auto_detect.py
+++ b/src/agentabi/auto_detect.py
@@ -7,8 +7,6 @@ and getting agent capabilities.
 
 from __future__ import annotations
 
-from typing import List
-
 from .providers.registry import (
     AgentNotAvailable,
     get_provider,
@@ -17,7 +15,7 @@ from .providers.registry import (
 from .types.ir.capabilities import AgentCapabilities
 
 
-def detect_agents() -> List[str]:
+def detect_agents() -> list[str]:
     """Detect which agents have at least one available provider.
 
     Returns:

--- a/src/agentabi/providers/base.py
+++ b/src/agentabi/providers/base.py
@@ -7,7 +7,8 @@ abstraction layer between Session and agent CLIs/SDKs.
 
 from __future__ import annotations
 
-from typing import Any, AsyncIterator, List
+from collections.abc import AsyncIterator
+from typing import Any
 
 from typing_extensions import Protocol, runtime_checkable
 
@@ -70,6 +71,78 @@ class Provider(Protocol):
         ...
 
 
+class _RunState:
+    """Mutable accumulator for default_run event aggregation."""
+
+    __slots__ = (
+        "session_id",
+        "delta_parts",
+        "result_text",
+        "status",
+        "model",
+        "cost_usd",
+        "errors",
+        "usage",
+    )
+
+    def __init__(self) -> None:
+        self.session_id = ""
+        self.delta_parts: list[str] = []
+        self.result_text = ""
+        self.status: SessionStatus = "success"
+        self.model = ""
+        self.cost_usd = 0.0
+        self.errors: list[str] = []
+        self.usage: UsageInfo = {}
+
+    def handle(self, event: IREvent) -> None:
+        """Dispatch a single IR event into the accumulator."""
+        etype = event.get("type")
+        if etype == "session_start":
+            self.session_id = event.get("session_id", "")
+            self.model = event.get("model", "")
+        elif etype == "message_delta":
+            text = event.get("text", "")
+            if text:
+                self.delta_parts.append(text)
+        elif etype == "message_end":
+            self._flush_message(event)
+        elif etype == "usage":
+            self.usage = event.get("usage", {})
+            cost = event.get("cost_usd")
+            if cost is not None:
+                self.cost_usd = cost
+        elif etype == "error":
+            self.errors.append(event.get("error", ""))
+            if event.get("is_fatal"):
+                self.status = "error"
+
+    def _flush_message(self, event: IREvent) -> None:
+        text = event.get("text")
+        if text:
+            self.result_text = text
+        elif self.delta_parts:
+            self.result_text = "".join(self.delta_parts)
+        self.delta_parts = []
+
+    def build(self) -> SessionResult:
+        result: SessionResult = {
+            "session_id": self.session_id,
+            "status": self.status,
+        }
+        if self.model:
+            result["model"] = self.model
+        if self.result_text:
+            result["result_text"] = self.result_text
+        if self.usage:
+            result["usage"] = self.usage
+        if self.cost_usd:
+            result["cost_usd"] = self.cost_usd
+        if self.errors:
+            result["errors"] = self.errors
+        return result
+
+
 async def default_run(provider: Any, task: TaskConfig) -> SessionResult:
     """Default run() implementation that aggregates stream() events.
 
@@ -82,57 +155,10 @@ async def default_run(provider: Any, task: TaskConfig) -> SessionResult:
     Returns:
         Aggregated SessionResult built from stream events.
     """
-    session_id = ""
-    delta_parts: List[str] = []
-    result_text = ""
-    status: SessionStatus = "success"
-    model = ""
-    cost_usd = 0.0
-    errors: List[str] = []
-    usage: UsageInfo = {}
-
+    state = _RunState()
     async for event in provider.stream(task):
-        etype = event.get("type")
-        if etype == "session_start":
-            session_id = event.get("session_id", "")
-            model = event.get("model", "")
-        elif etype == "message_delta":
-            text = event.get("text", "")
-            if text:
-                delta_parts.append(text)
-        elif etype == "message_end":
-            text = event.get("text")
-            if text:
-                result_text = text
-            elif delta_parts:
-                result_text = "".join(delta_parts)
-            delta_parts = []
-        elif etype == "usage":
-            usage = event.get("usage", {})
-            cost = event.get("cost_usd")
-            if cost is not None:
-                cost_usd = cost
-        elif etype == "error":
-            errors.append(event.get("error", ""))
-            if event.get("is_fatal"):
-                status = "error"
-
-    result: SessionResult = {
-        "session_id": session_id,
-        "status": status,
-    }
-    if model:
-        result["model"] = model
-    if result_text:
-        result["result_text"] = result_text
-    if usage:
-        result["usage"] = usage
-    if cost_usd:
-        result["cost_usd"] = cost_usd
-    if errors:
-        result["errors"] = errors
-
-    return result
+        state.handle(event)
+    return state.build()
 
 
 __all__ = [

--- a/src/agentabi/providers/claude_native.py
+++ b/src/agentabi/providers/claude_native.py
@@ -11,7 +11,8 @@ import asyncio
 import json
 import os
 import shutil
-from typing import Any, AsyncIterator, Dict, List, cast
+from collections.abc import AsyncIterator
+from typing import Any, cast
 
 from ..types.ir.capabilities import AgentCapabilities
 from ..types.ir.events import (
@@ -29,6 +30,15 @@ from ..types.ir.events import (
 )
 from ..types.ir.session import SessionResult
 from ..types.ir.task import TaskConfig
+
+_PERMISSION_LEVEL_MAP: dict[str, str] = {
+    "full_auto": "bypassPermissions",
+    "accept_edits": "acceptEdits",
+    "plan": "plan",
+    "auto": "auto",
+    "dont_ask": "dontAsk",
+    "default": "default",
+}
 
 
 class ClaudeNativeProvider:
@@ -102,7 +112,7 @@ class ClaudeNativeProvider:
     # ========== Private: command building ==========
 
     @staticmethod
-    def _build_command(task: TaskConfig) -> List[str]:
+    def _build_command(task: TaskConfig) -> list[str]:
         """Convert TaskConfig to `claude` CLI arguments."""
         cmd = ["claude", "--print", "--output-format", "stream-json", "--verbose"]
 
@@ -123,12 +133,9 @@ class ClaudeNativeProvider:
         permissions = task.get("permissions")
         if permissions:
             level = permissions.get("level")
-            if level == "full_auto":
-                cmd.append("--dangerously-skip-permissions")
-            elif level == "accept_edits":
-                cmd.extend(["--permission-mode", "acceptEdits"])
-            elif level == "plan":
-                cmd.extend(["--permission-mode", "plan"])
+            cli_mode = _PERMISSION_LEVEL_MAP.get(level or "")
+            if cli_mode:
+                cmd.extend(["--permission-mode", cli_mode])
 
         if "allowed_tools" in task:
             cmd.extend(["--allowed-tools", ",".join(task["allowed_tools"])])
@@ -161,7 +168,7 @@ class ClaudeNativeProvider:
     # ========== Private: event parsing ==========
 
     @staticmethod
-    def _parse_event(event: Dict[str, Any]) -> List[IREvent]:
+    def _parse_event(event: dict[str, Any]) -> list[IREvent]:
         """Convert a Claude Code JSONL event to IR event(s)."""
         event_type = event.get("type")
 
@@ -178,7 +185,7 @@ class ClaudeNativeProvider:
         return []
 
     @staticmethod
-    def _handle_system(event: Dict[str, Any]) -> List[IREvent]:
+    def _handle_system(event: dict[str, Any]) -> list[IREvent]:
         ir: SessionStartEvent = {
             "type": "session_start",
             "session_id": event.get("session_id", ""),
@@ -193,8 +200,8 @@ class ClaudeNativeProvider:
         return [ir]
 
     @staticmethod
-    def _handle_assistant(event: Dict[str, Any]) -> List[IREvent]:
-        results: List[IREvent] = []
+    def _handle_assistant(event: dict[str, Any]) -> list[IREvent]:
+        results: list[IREvent] = []
         message = event.get("message", {})
         content = message.get("content", [])
         message_id = message.get("id", "")
@@ -231,8 +238,8 @@ class ClaudeNativeProvider:
         return results
 
     @staticmethod
-    def _handle_user(event: Dict[str, Any]) -> List[IREvent]:
-        results: List[IREvent] = []
+    def _handle_user(event: dict[str, Any]) -> list[IREvent]:
+        results: list[IREvent] = []
         message = event.get("message", {})
         content = message.get("content", [])
 
@@ -257,7 +264,7 @@ class ClaudeNativeProvider:
         return results
 
     @staticmethod
-    def _handle_stream_event(event: Dict[str, Any]) -> List[IREvent]:
+    def _handle_stream_event(event: dict[str, Any]) -> list[IREvent]:
         inner = event.get("event", {})
         if inner.get("type") == "content_block_delta":
             delta = inner.get("delta", {})
@@ -269,8 +276,8 @@ class ClaudeNativeProvider:
         return []
 
     @staticmethod
-    def _handle_result(event: Dict[str, Any]) -> List[IREvent]:
-        results: List[IREvent] = []
+    def _handle_result(event: dict[str, Any]) -> list[IREvent]:
+        results: list[IREvent] = []
 
         raw_usage = event.get("usage", {})
         usage: UsageInfo = {}

--- a/src/agentabi/providers/claude_sdk.py
+++ b/src/agentabi/providers/claude_sdk.py
@@ -6,7 +6,8 @@ Wraps claude-agent-sdk behind the Provider protocol.
 
 from __future__ import annotations
 
-from typing import Any, AsyncIterator
+from collections.abc import AsyncIterator
+from typing import Any
 
 from ..types.ir.capabilities import AgentCapabilities
 from ..types.ir.events import (
@@ -75,6 +76,12 @@ class ClaudeSDKProvider:
                 options.permission_mode = "acceptEdits"
             elif level == "plan":
                 options.permission_mode = "plan"
+            elif level == "auto":
+                options.permission_mode = "auto"
+            elif level == "dont_ask":
+                options.permission_mode = "dontAsk"
+            elif level == "default":
+                options.permission_mode = "default"
 
         async for msg in query(prompt=task["prompt"], options=options):
             for event in self._convert(msg):

--- a/src/agentabi/providers/codex_native.py
+++ b/src/agentabi/providers/codex_native.py
@@ -11,7 +11,8 @@ import asyncio
 import json
 import os
 import shutil
-from typing import Any, AsyncIterator, Dict, List, Literal, cast
+from collections.abc import AsyncIterator
+from typing import Any, Literal, cast
 
 from ..types.ir.capabilities import AgentCapabilities
 from ..types.ir.events import (
@@ -105,7 +106,7 @@ class CodexNativeProvider:
         return await default_run(self, task)
 
     @staticmethod
-    def _build_command(task: TaskConfig) -> List[str]:
+    def _build_command(task: TaskConfig) -> list[str]:
         """Convert TaskConfig to codex CLI arguments."""
         cmd = ["codex", "exec", "--json", "--full-auto"]
 
@@ -125,7 +126,7 @@ class CodexNativeProvider:
         return cmd
 
     @staticmethod
-    def _parse_event(raw: Dict[str, Any]) -> List[IREvent]:
+    def _parse_event(raw: dict[str, Any]) -> list[IREvent]:
         """Convert a Codex CLI JSONL event to IR events."""
         event_type = raw.get("type")
 
@@ -142,7 +143,7 @@ class CodexNativeProvider:
         return []
 
     @staticmethod
-    def _handle_thread_started(raw: Dict[str, Any]) -> List[IREvent]:
+    def _handle_thread_started(raw: dict[str, Any]) -> list[IREvent]:
         start: SessionStartEvent = {
             "type": "session_start",
             "session_id": raw.get("thread_id", ""),
@@ -151,7 +152,7 @@ class CodexNativeProvider:
         return [start]
 
     @staticmethod
-    def _handle_turn_started() -> List[IREvent]:
+    def _handle_turn_started() -> list[IREvent]:
         msg_start: MessageStartEvent = {
             "type": "message_start",
             "role": "assistant",
@@ -159,8 +160,8 @@ class CodexNativeProvider:
         return [msg_start]
 
     @staticmethod
-    def _handle_turn_completed(raw: Dict[str, Any]) -> List[IREvent]:
-        results: List[IREvent] = []
+    def _handle_turn_completed(raw: dict[str, Any]) -> list[IREvent]:
+        results: list[IREvent] = []
 
         usage_raw = raw.get("usage", {})
         usage: UsageInfo = {}
@@ -190,7 +191,7 @@ class CodexNativeProvider:
         return results
 
     @staticmethod
-    def _handle_item(raw: Dict[str, Any], *, started: bool) -> List[IREvent]:
+    def _handle_item(raw: dict[str, Any], *, started: bool) -> list[IREvent]:
         """Convert an item.started or item.completed event to IR events."""
         item = raw.get("item", {})
         item_type = item.get("type", "")
@@ -213,7 +214,7 @@ class CodexNativeProvider:
         return []
 
     @staticmethod
-    def _handle_agent_message(item: Dict[str, Any], *, started: bool) -> List[IREvent]:
+    def _handle_agent_message(item: dict[str, Any], *, started: bool) -> list[IREvent]:
         if started:
             return []
         text = item.get("text", "")
@@ -226,7 +227,7 @@ class CodexNativeProvider:
         return [delta]
 
     @staticmethod
-    def _handle_command(item: Dict[str, Any], *, started: bool) -> List[IREvent]:
+    def _handle_command(item: dict[str, Any], *, started: bool) -> list[IREvent]:
         item_id = item.get("id", "")
         if started:
             tool_use: ToolUseEvent = {
@@ -247,13 +248,13 @@ class CodexNativeProvider:
             return [tool_result]
 
     @staticmethod
-    def _handle_file_change(item: Dict[str, Any], *, started: bool) -> List[IREvent]:
+    def _handle_file_change(item: dict[str, Any], *, started: bool) -> list[IREvent]:
         if started:
             return []
-        results: List[IREvent] = []
+        results: list[IREvent] = []
         for change in item.get("changes", []):
             kind = change.get("kind", "update")
-            action_map: Dict[str, str] = {
+            action_map: dict[str, str] = {
                 "add": "create",
                 "delete": "delete",
                 "update": "modify",
@@ -269,7 +270,7 @@ class CodexNativeProvider:
         return results
 
     @staticmethod
-    def _handle_mcp_tool(item: Dict[str, Any], *, started: bool) -> List[IREvent]:
+    def _handle_mcp_tool(item: dict[str, Any], *, started: bool) -> list[IREvent]:
         item_id = item.get("id", "")
         if started:
             server = item.get("server", "")

--- a/src/agentabi/providers/codex_sdk.py
+++ b/src/agentabi/providers/codex_sdk.py
@@ -6,7 +6,8 @@ Wraps codex-sdk-python behind the Provider protocol.
 
 from __future__ import annotations
 
-from typing import Any, AsyncIterator, Literal, cast
+from collections.abc import AsyncIterator
+from typing import Any, Literal, cast
 
 from ..types.ir.capabilities import AgentCapabilities
 from ..types.ir.events import (

--- a/src/agentabi/providers/gemini_native.py
+++ b/src/agentabi/providers/gemini_native.py
@@ -11,7 +11,8 @@ import asyncio
 import json
 import os
 import shutil
-from typing import Any, AsyncIterator, Dict, List
+from collections.abc import AsyncIterator
+from typing import Any
 
 from ..types.ir.capabilities import AgentCapabilities
 from ..types.ir.events import (
@@ -104,16 +105,32 @@ class GeminiNativeProvider:
         return await default_run(self, task)
 
     @staticmethod
-    def _build_command(task: TaskConfig) -> List[str]:
+    def _build_command(task: TaskConfig) -> list[str]:
         """Convert TaskConfig to gemini CLI arguments."""
-        cmd = ["gemini", "-o", "stream-json", "-y"]
+        cmd = ["gemini", "-o", "stream-json"]
+
+        permissions = task.get("permissions")
+        if permissions:
+            level = permissions.get("level")
+            if level == "full_auto":
+                cmd.extend(["--approval-mode", "yolo"])
+            elif level == "accept_edits":
+                cmd.extend(["--approval-mode", "auto_edit"])
+            elif level == "plan":
+                cmd.extend(["--approval-mode", "plan"])
+            elif level == "default":
+                cmd.extend(["--approval-mode", "default"])
+            else:
+                cmd.extend(["--approval-mode", "yolo"])
+        else:
+            cmd.extend(["--approval-mode", "yolo"])
 
         if "model" in task:
             cmd.extend(["-m", task["model"]])
 
         if "system_prompt" in task:
             # Gemini CLI uses -s for sandbox, no direct system prompt flag.
-            # Pass as GEMINI_SYSTEM_PROMPT env var if supported.
+            # system_prompt in TaskConfig is ignored for this provider.
             pass
 
         if task.get("resume"):
@@ -124,7 +141,7 @@ class GeminiNativeProvider:
         return cmd
 
     @staticmethod
-    def _parse_event(raw: Dict[str, Any]) -> List[IREvent]:
+    def _parse_event(raw: dict[str, Any]) -> list[IREvent]:
         """Convert a Gemini CLI stream-json event to IR events."""
         event_type = raw.get("type")
 
@@ -141,7 +158,7 @@ class GeminiNativeProvider:
         return []
 
     @staticmethod
-    def _handle_init(raw: Dict[str, Any]) -> List[IREvent]:
+    def _handle_init(raw: dict[str, Any]) -> list[IREvent]:
         start: SessionStartEvent = {
             "type": "session_start",
             "session_id": raw.get("session_id", ""),
@@ -153,7 +170,7 @@ class GeminiNativeProvider:
         return [start]
 
     @staticmethod
-    def _handle_message(raw: Dict[str, Any]) -> List[IREvent]:
+    def _handle_message(raw: dict[str, Any]) -> list[IREvent]:
         role = raw.get("role", "")
         if role == "user":
             return []
@@ -171,7 +188,7 @@ class GeminiNativeProvider:
             return []
 
         # Non-delta assistant message: full text
-        results: List[IREvent] = []
+        results: list[IREvent] = []
         msg_start: MessageStartEvent = {
             "type": "message_start",
             "role": "assistant",
@@ -185,7 +202,7 @@ class GeminiNativeProvider:
         return results
 
     @staticmethod
-    def _handle_tool_use(raw: Dict[str, Any]) -> List[IREvent]:
+    def _handle_tool_use(raw: dict[str, Any]) -> list[IREvent]:
         tool_event: ToolUseEvent = {
             "type": "tool_use",
             "tool_use_id": raw.get("tool_id", ""),
@@ -195,7 +212,7 @@ class GeminiNativeProvider:
         return [tool_event]
 
     @staticmethod
-    def _handle_tool_result(raw: Dict[str, Any]) -> List[IREvent]:
+    def _handle_tool_result(raw: dict[str, Any]) -> list[IREvent]:
         result: ToolResultEvent = {
             "type": "tool_result",
             "tool_use_id": raw.get("tool_id", ""),
@@ -212,8 +229,8 @@ class GeminiNativeProvider:
         return [result]
 
     @staticmethod
-    def _handle_result(raw: Dict[str, Any]) -> List[IREvent]:
-        results: List[IREvent] = []
+    def _handle_result(raw: dict[str, Any]) -> list[IREvent]:
+        results: list[IREvent] = []
         stats = raw.get("stats", {})
 
         usage: UsageInfo = {}

--- a/src/agentabi/providers/gemini_sdk.py
+++ b/src/agentabi/providers/gemini_sdk.py
@@ -6,7 +6,8 @@ Wraps gemini-cli-sdk behind the Provider protocol.
 
 from __future__ import annotations
 
-from typing import Any, AsyncIterator
+from collections.abc import AsyncIterator
+from typing import Any
 
 from ..types.ir.capabilities import AgentCapabilities
 from ..types.ir.events import (

--- a/src/agentabi/providers/opencode_native.py
+++ b/src/agentabi/providers/opencode_native.py
@@ -11,7 +11,8 @@ import asyncio
 import json
 import os
 import shutil
-from typing import Any, AsyncIterator, Dict, List
+from collections.abc import AsyncIterator
+from typing import Any
 
 from ..types.ir.capabilities import AgentCapabilities
 from ..types.ir.events import (
@@ -51,7 +52,7 @@ class OpenCodeNativeProvider:
             "supports_session_resume": True,
             "supports_system_prompt": True,
             "supports_tool_filtering": False,
-            "supports_permissions": False,
+            "supports_permissions": True,
             "supports_multi_turn": False,
             "transport": "subprocess",
         }
@@ -96,15 +97,15 @@ class OpenCodeNativeProvider:
         return await default_run(self, task)
 
     @staticmethod
-    def _build_command(task: TaskConfig) -> List[str]:
+    def _build_command(task: TaskConfig) -> list[str]:
         """Convert TaskConfig to opencode CLI arguments."""
         cmd = ["opencode", "run", "--format", "json"]
 
         if "model" in task:
             cmd.extend(["--model", task["model"]])
 
-        if "system_prompt" in task:
-            cmd.extend(["--prompt", task["system_prompt"]])
+        # Note: OpenCode CLI does not support system prompts via CLI flags.
+        # system_prompt in TaskConfig is ignored for this provider.
 
         if "working_dir" in task:
             cmd.extend(["--dir", task["working_dir"]])
@@ -112,12 +113,18 @@ class OpenCodeNativeProvider:
         if task.get("resume") and "session_id" in task:
             cmd.extend(["--session", task["session_id"]])
 
+        permissions = task.get("permissions")
+        if permissions:
+            level = permissions.get("level")
+            if level == "full_auto":
+                cmd.append("--dangerously-skip-permissions")
+
         cmd.append("--")
         cmd.append(task["prompt"])
         return cmd
 
     @staticmethod
-    def _parse_event(raw: Dict[str, Any]) -> List[IREvent]:
+    def _parse_event(raw: dict[str, Any]) -> list[IREvent]:
         """Convert an OpenCode JSON event to IR events.
 
         OpenCode JSON format (--format json):
@@ -141,8 +148,8 @@ class OpenCodeNativeProvider:
         return []
 
     @staticmethod
-    def _handle_step_start(part: Dict[str, Any], session_id: str) -> List[IREvent]:
-        results: List[IREvent] = []
+    def _handle_step_start(part: dict[str, Any], session_id: str) -> list[IREvent]:
+        results: list[IREvent] = []
         start: SessionStartEvent = {
             "type": "session_start",
             "session_id": session_id,
@@ -161,7 +168,7 @@ class OpenCodeNativeProvider:
         return results
 
     @staticmethod
-    def _handle_text(part: Dict[str, Any]) -> List[IREvent]:
+    def _handle_text(part: dict[str, Any]) -> list[IREvent]:
         text = part.get("text", "")
         if text:
             delta: MessageDeltaEvent = {"type": "message_delta", "text": text}
@@ -169,8 +176,8 @@ class OpenCodeNativeProvider:
         return []
 
     @staticmethod
-    def _handle_tool_use(part: Dict[str, Any]) -> List[IREvent]:
-        results: List[IREvent] = []
+    def _handle_tool_use(part: dict[str, Any]) -> list[IREvent]:
+        results: list[IREvent] = []
         state = part.get("state", {})
         tool_name = part.get("tool", "")
         call_id = part.get("callID", "")
@@ -210,8 +217,8 @@ class OpenCodeNativeProvider:
         return results
 
     @staticmethod
-    def _handle_step_finish(part: Dict[str, Any], session_id: str) -> List[IREvent]:
-        results: List[IREvent] = []
+    def _handle_step_finish(part: dict[str, Any], session_id: str) -> list[IREvent]:
+        results: list[IREvent] = []
 
         tokens = part.get("tokens", {})
         usage: UsageInfo = {}

--- a/src/agentabi/providers/registry.py
+++ b/src/agentabi/providers/registry.py
@@ -7,8 +7,6 @@ resolve_provider() tries each in order, returning the first available.
 
 from __future__ import annotations
 
-from typing import Dict, List, Type
-
 from .base import Provider
 
 
@@ -25,7 +23,7 @@ class AgentNotAvailable(Exception):
         super().__init__(f"No provider available for agent '{agent}'.{hint}")
 
 
-def _build_provider_chain() -> Dict[str, List[Type[Provider]]]:
+def _build_provider_chain() -> dict[str, list[type[Provider]]]:
     """Build the provider chain lazily to avoid circular imports."""
     from .claude_native import ClaudeNativeProvider
 
@@ -46,10 +44,10 @@ def _build_provider_chain() -> Dict[str, List[Type[Provider]]]:
     }
 
 
-_chain_cache: Dict[str, List[Type[Provider]]] | None = None
+_chain_cache: dict[str, list[type[Provider]]] | None = None
 
 
-def _get_chain() -> Dict[str, List[Type[Provider]]]:
+def _get_chain() -> dict[str, list[type[Provider]]]:
     global _chain_cache
     if _chain_cache is None:
         _chain_cache = _build_provider_chain()
@@ -100,7 +98,7 @@ def get_provider(agent: str, *, prefer: str | None = None) -> Provider:
     return resolve_provider(agent, prefer=prefer)
 
 
-def list_agents() -> List[str]:
+def list_agents() -> list[str]:
     """List all registered agent names (regardless of availability).
 
     Returns:
@@ -109,7 +107,7 @@ def list_agents() -> List[str]:
     return list(_get_chain().keys())
 
 
-def list_available_agents() -> List[str]:
+def list_available_agents() -> list[str]:
     """List agents that have at least one available provider.
 
     Returns:

--- a/src/agentabi/session.py
+++ b/src/agentabi/session.py
@@ -8,7 +8,8 @@ Async-first design with sync convenience wrapper.
 from __future__ import annotations
 
 import asyncio
-from typing import Any, AsyncIterator, Optional, cast
+from collections.abc import AsyncIterator
+from typing import Any, cast
 
 from .providers.base import Provider
 from .providers.registry import resolve_provider
@@ -39,9 +40,9 @@ class Session:
     def __init__(
         self,
         *,
-        agent: Optional[str] = None,
-        model: Optional[str] = None,
-        prefer: Optional[str] = None,
+        agent: str | None = None,
+        model: str | None = None,
+        prefer: str | None = None,
     ) -> None:
         """Initialize a Session.
 
@@ -71,7 +72,7 @@ class Session:
         return self._agent
 
     @property
-    def model(self) -> Optional[str]:
+    def model(self) -> str | None:
         """The default model, if set."""
         return self._model
 
@@ -84,9 +85,9 @@ class Session:
         self,
         prompt: str,
         *,
-        working_dir: Optional[str] = None,
-        max_turns: Optional[int] = None,
-        system_prompt: Optional[str] = None,
+        working_dir: str | None = None,
+        max_turns: int | None = None,
+        system_prompt: str | None = None,
         **kwargs,
     ) -> AsyncIterator[IREvent]:
         """Stream IR events from a task execution.
@@ -115,9 +116,9 @@ class Session:
         self,
         prompt: str,
         *,
-        working_dir: Optional[str] = None,
-        max_turns: Optional[int] = None,
-        system_prompt: Optional[str] = None,
+        working_dir: str | None = None,
+        max_turns: int | None = None,
+        system_prompt: str | None = None,
         **kwargs,
     ) -> SessionResult:
         """Run a task to completion.
@@ -145,9 +146,9 @@ class Session:
         self,
         prompt: str,
         *,
-        working_dir: Optional[str] = None,
-        max_turns: Optional[int] = None,
-        system_prompt: Optional[str] = None,
+        working_dir: str | None = None,
+        max_turns: int | None = None,
+        system_prompt: str | None = None,
         **kwargs,
     ) -> TaskConfig:
         """Build a TaskConfig from arguments."""
@@ -173,8 +174,8 @@ class Session:
 def run_sync(
     prompt: str,
     *,
-    agent: Optional[str] = None,
-    model: Optional[str] = None,
+    agent: str | None = None,
+    model: str | None = None,
     **kwargs,
 ) -> SessionResult:
     """Synchronous convenience for running a task.

--- a/src/agentabi/types/ir/events.py
+++ b/src/agentabi/types/ir/events.py
@@ -13,7 +13,7 @@ Event categories:
     - File changes: file_diff
 """
 
-from typing import Any, Dict, List, Literal, Union
+from typing import Any, Literal, Union
 
 from typing_extensions import NotRequired, Required, TypedDict
 
@@ -33,7 +33,7 @@ class SessionStartEvent(TypedDict):
     session_id: Required[str]
     agent: NotRequired[str]  # agent type identifier
     model: NotRequired[str]
-    tools: NotRequired[List[str]]
+    tools: NotRequired[list[str]]
     working_dir: NotRequired[str]
 
 
@@ -94,7 +94,7 @@ class ToolUseEvent(TypedDict):
     type: Required[Literal["tool_use"]]
     tool_use_id: Required[str]
     tool_name: Required[str]
-    tool_input: Required[Dict[str, Any]]
+    tool_input: Required[dict[str, Any]]
 
 
 class ToolResultEvent(TypedDict):
@@ -124,7 +124,7 @@ class PermissionRequestEvent(TypedDict):
     type: Required[Literal["permission_request"]]
     tool_name: Required[str]
     tool_use_id: Required[str]
-    tool_input: NotRequired[Dict[str, Any]]
+    tool_input: NotRequired[dict[str, Any]]
     description: NotRequired[str]
 
 

--- a/src/agentabi/types/ir/helpers.py
+++ b/src/agentabi/types/ir/helpers.py
@@ -4,7 +4,7 @@ agentabi - IR Helpers
 Convenience constructors for creating IR events and types.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from .events import (
     ErrorEvent,
@@ -21,7 +21,7 @@ def create_session_start_event(
     *,
     agent: Optional[str] = None,
     model: Optional[str] = None,
-    tools: Optional[List[str]] = None,
+    tools: Optional[list[str]] = None,
     working_dir: Optional[str] = None,
 ) -> SessionStartEvent:
     """Create a SessionStartEvent with optional metadata."""
@@ -58,7 +58,7 @@ def create_message_delta_event(
 def create_tool_use_event(
     tool_use_id: str,
     tool_name: str,
-    tool_input: Dict[str, Any],
+    tool_input: dict[str, Any],
 ) -> ToolUseEvent:
     """Create a ToolUseEvent."""
     return {

--- a/src/agentabi/types/ir/permissions.py
+++ b/src/agentabi/types/ir/permissions.py
@@ -4,7 +4,7 @@ agentabi - Permission Types
 Defines permission configuration and request types for the agent ABI.
 """
 
-from typing import List, Literal
+from typing import Literal
 
 from typing_extensions import NotRequired, Required, TypedDict
 
@@ -16,7 +16,9 @@ PermissionLevel = Literal[
     "default",  # prompt for sensitive operations
     "accept_edits",  # auto-approve file edits
     "plan",  # planning mode, no execution
-    "full_auto",  # auto-approve everything
+    "full_auto",  # auto-approve everything (bypass all checks)
+    "auto",  # auto mode (agent decides)
+    "dont_ask",  # never prompt, skip if not auto-approved
 ]
 
 # ============================================================================
@@ -31,8 +33,8 @@ class PermissionConfig(TypedDict):
     """
 
     level: NotRequired[PermissionLevel]
-    allowed_tools: NotRequired[List[str]]
-    disallowed_tools: NotRequired[List[str]]
+    allowed_tools: NotRequired[list[str]]
+    disallowed_tools: NotRequired[list[str]]
     sandbox: NotRequired[bool]  # run in sandboxed environment
 
 

--- a/src/agentabi/types/ir/session.py
+++ b/src/agentabi/types/ir/session.py
@@ -5,7 +5,7 @@ Defines SessionResult, the unified output type after an agent session completes.
 Analogous to llmir's IRResponse.
 """
 
-from typing import Any, Dict, List, Literal
+from typing import Any, Literal
 
 from typing_extensions import NotRequired, Required, TypedDict
 
@@ -48,7 +48,7 @@ class SessionResult(TypedDict):
     result_text: NotRequired[str]
 
     # ========== File Changes ==========
-    file_diffs: NotRequired[List[FileDiffEvent]]
+    file_diffs: NotRequired[list[FileDiffEvent]]
 
     # ========== Usage ==========
     usage: NotRequired[UsageInfo]
@@ -58,10 +58,10 @@ class SessionResult(TypedDict):
 
     # ========== Error ==========
     error: NotRequired[str]
-    errors: NotRequired[List[str]]
+    errors: NotRequired[list[str]]
 
     # ========== Agent-Specific ==========
-    agent_extensions: NotRequired[Dict[str, Any]]
+    agent_extensions: NotRequired[dict[str, Any]]
 
 
 # ============================================================================

--- a/src/agentabi/types/ir/task.py
+++ b/src/agentabi/types/ir/task.py
@@ -5,7 +5,7 @@ Defines TaskConfig, the unified input type for submitting work to any agent CLI.
 Analogous to llmir's IRRequest.
 """
 
-from typing import Any, Dict, List, Literal
+from typing import Any, Literal
 
 from typing_extensions import NotRequired, Required, TypedDict
 
@@ -54,7 +54,7 @@ class TaskConfig(TypedDict):
 
     # ========== Execution Context ==========
     working_dir: NotRequired[str]
-    env: NotRequired[Dict[str, str]]
+    env: NotRequired[dict[str, str]]
 
     # ========== Session Management ==========
     session_id: NotRequired[str]
@@ -68,14 +68,14 @@ class TaskConfig(TypedDict):
 
     # ========== Permission Control ==========
     permissions: NotRequired[PermissionConfig]
-    allowed_tools: NotRequired[List[str]]
-    disallowed_tools: NotRequired[List[str]]
+    allowed_tools: NotRequired[list[str]]
+    disallowed_tools: NotRequired[list[str]]
 
     # ========== MCP ==========
     mcp_config: NotRequired[str]  # path to MCP config file
 
     # ========== Agent-Specific Extensions ==========
-    agent_extensions: NotRequired[Dict[str, Any]]
+    agent_extensions: NotRequired[dict[str, Any]]
 
 
 __all__ = [

--- a/src/agentabi/types/ir/type_guards.py
+++ b/src/agentabi/types/ir/type_guards.py
@@ -5,7 +5,7 @@ Type guard functions for discriminating IREvent union types.
 Follows the llmir is_part_type() pattern.
 """
 
-from typing import Any, Dict, Type, Union
+from typing import Any, Union
 
 from .events import (
     ErrorEvent,
@@ -27,7 +27,7 @@ from .events import (
 # Type → string mapping
 # ============================================================================
 
-EVENT_TYPE_MAP: Dict[str, Type[IREvent]] = {
+EVENT_TYPE_MAP: dict[str, type[IREvent]] = {
     "session_start": SessionStartEvent,
     "session_end": SessionEndEvent,
     "message_start": MessageStartEvent,
@@ -43,7 +43,7 @@ EVENT_TYPE_MAP: Dict[str, Type[IREvent]] = {
 }
 
 
-def is_event_type(event: Any, event_class: Type) -> bool:
+def is_event_type(event: Any, event_class: type) -> bool:
     """Check if an event dict matches a specific IREvent type.
 
     Args:
@@ -78,7 +78,7 @@ def is_event_type(event: Any, event_class: Type) -> bool:
     return event_type == expected_type
 
 
-def get_event_type(event: Any) -> Union[Type[IREvent], None]:
+def get_event_type(event: Any) -> Union[type[IREvent], None]:
     """Get the TypedDict class for an event dict.
 
     Args:

--- a/tests/providers/test_claude_native.py
+++ b/tests/providers/test_claude_native.py
@@ -43,7 +43,8 @@ class TestBuildCommand:
         cmd = ClaudeNativeProvider._build_command(
             {"prompt": "hi", "permissions": {"level": "full_auto"}}
         )
-        assert "--dangerously-skip-permissions" in cmd
+        idx = cmd.index("--permission-mode")
+        assert cmd[idx + 1] == "bypassPermissions"
 
     def test_plan_mode_permissions(self):
         cmd = ClaudeNativeProvider._build_command(
@@ -51,6 +52,27 @@ class TestBuildCommand:
         )
         idx = cmd.index("--permission-mode")
         assert cmd[idx + 1] == "plan"
+
+    def test_auto_mode_permissions(self):
+        cmd = ClaudeNativeProvider._build_command(
+            {"prompt": "hi", "permissions": {"level": "auto"}}
+        )
+        idx = cmd.index("--permission-mode")
+        assert cmd[idx + 1] == "auto"
+
+    def test_dont_ask_permissions(self):
+        cmd = ClaudeNativeProvider._build_command(
+            {"prompt": "hi", "permissions": {"level": "dont_ask"}}
+        )
+        idx = cmd.index("--permission-mode")
+        assert cmd[idx + 1] == "dontAsk"
+
+    def test_default_permissions(self):
+        cmd = ClaudeNativeProvider._build_command(
+            {"prompt": "hi", "permissions": {"level": "default"}}
+        )
+        idx = cmd.index("--permission-mode")
+        assert cmd[idx + 1] == "default"
 
     def test_with_mcp_config(self):
         cmd = ClaudeNativeProvider._build_command(

--- a/tests/providers/test_claude_sdk.py
+++ b/tests/providers/test_claude_sdk.py
@@ -1,7 +1,7 @@
 """Tests for ClaudeSDKProvider event conversion."""
 
 from dataclasses import dataclass, field
-from typing import Any, List, Optional
+from typing import Any, Optional
 from unittest.mock import patch
 
 
@@ -33,7 +33,7 @@ class MockToolResultBlock:
 
 @dataclass
 class MockAssistantMessage:
-    content: List[Any] = field(default_factory=list)
+    content: list[Any] = field(default_factory=list)
     model: str = "claude-sonnet-4-20250514"
     message_id: Optional[str] = None
     stop_reason: Optional[str] = None

--- a/tests/providers/test_codex_sdk.py
+++ b/tests/providers/test_codex_sdk.py
@@ -1,7 +1,7 @@
 """Tests for CodexSDKProvider event conversion."""
 
 from dataclasses import dataclass, field
-from typing import Any, List, Literal, Optional
+from typing import Any, Literal, Optional
 from unittest.mock import patch
 
 
@@ -68,7 +68,7 @@ class MockFileUpdateChange:
 class MockFileChangeItem:
     id: str = "item-3"
     type: Literal["file_change"] = "file_change"
-    changes: List[MockFileUpdateChange] = field(default_factory=list)
+    changes: list[MockFileUpdateChange] = field(default_factory=list)
     status: str = "completed"
 
 

--- a/tests/providers/test_gemini_native.py
+++ b/tests/providers/test_gemini_native.py
@@ -18,7 +18,8 @@ class TestBuildCommand:
             "gemini",
             "-o",
             "stream-json",
-            "-y",
+            "--approval-mode",
+            "yolo",
             "-p",
             "Hello",
         ]
@@ -56,6 +57,46 @@ class TestBuildCommand:
         assert "-p" in cmd
         p_idx = cmd.index("-p")
         assert cmd[p_idx + 1] == "What is 2+2?"
+
+    def test_full_auto_permissions(self):
+        task = self._task(
+            {
+                "prompt": "Hi",
+                "agent": "gemini_cli",
+                "permissions": {"level": "full_auto"},
+            }
+        )
+        cmd = GeminiNativeProvider._build_command(task)
+        idx = cmd.index("--approval-mode")
+        assert cmd[idx + 1] == "yolo"
+
+    def test_accept_edits_permissions(self):
+        task = self._task(
+            {
+                "prompt": "Hi",
+                "agent": "gemini_cli",
+                "permissions": {"level": "accept_edits"},
+            }
+        )
+        cmd = GeminiNativeProvider._build_command(task)
+        idx = cmd.index("--approval-mode")
+        assert cmd[idx + 1] == "auto_edit"
+
+    def test_plan_mode_permissions(self):
+        task = self._task(
+            {"prompt": "Hi", "agent": "gemini_cli", "permissions": {"level": "plan"}}
+        )
+        cmd = GeminiNativeProvider._build_command(task)
+        idx = cmd.index("--approval-mode")
+        assert cmd[idx + 1] == "plan"
+
+    def test_default_permissions(self):
+        task = self._task(
+            {"prompt": "Hi", "agent": "gemini_cli", "permissions": {"level": "default"}}
+        )
+        cmd = GeminiNativeProvider._build_command(task)
+        idx = cmd.index("--approval-mode")
+        assert cmd[idx + 1] == "default"
 
 
 class TestParseEvent:

--- a/tests/providers/test_gemini_sdk.py
+++ b/tests/providers/test_gemini_sdk.py
@@ -1,7 +1,7 @@
 """Tests for GeminiSDKProvider event conversion."""
 
 from dataclasses import dataclass, field
-from typing import Any, List, Optional
+from typing import Any, Optional
 from unittest.mock import patch
 
 
@@ -43,7 +43,7 @@ class MockUserMessage:
 
 @dataclass
 class MockAssistantMessage:
-    content: List[Any] = field(default_factory=list)
+    content: list[Any] = field(default_factory=list)
     type: str = "assistant"
 
 

--- a/tests/providers/test_opencode_native.py
+++ b/tests/providers/test_opencode_native.py
@@ -28,13 +28,25 @@ class TestBuildCommand:
         assert "--model" in cmd
         assert "anthropic/claude-sonnet-4-20250514" in cmd
 
-    def test_with_system_prompt(self):
+    def test_system_prompt_ignored(self):
         task = self._task(
             {"prompt": "Hi", "agent": "opencode", "system_prompt": "Be concise"}
         )
         cmd = OpenCodeNativeProvider._build_command(task)
-        assert "--prompt" in cmd
-        assert "Be concise" in cmd
+        assert "--prompt" not in cmd
+        assert "Be concise" not in cmd
+
+    def test_full_auto_permissions(self):
+        task = self._task(
+            {"prompt": "Hi", "agent": "opencode", "permissions": {"level": "full_auto"}}
+        )
+        cmd = OpenCodeNativeProvider._build_command(task)
+        assert "--dangerously-skip-permissions" in cmd
+
+    def test_no_permissions_flag_by_default(self):
+        task = self._task({"prompt": "Hi", "agent": "opencode"})
+        cmd = OpenCodeNativeProvider._build_command(task)
+        assert "--dangerously-skip-permissions" not in cmd
 
     def test_with_working_dir(self):
         task = self._task(


### PR DESCRIPTION
## Summary

- **OpenCode**: remove incorrect `--prompt` mapping for `system_prompt` (flag doesn't exist on `opencode run`), add `--dangerously-skip-permissions` support, update `supports_permissions` to `True`
- **Claude**: use `--permission-mode bypassPermissions` instead of `--dangerously-skip-permissions` for `full_auto`, add `auto`/`dont_ask`/`default` permission level mappings
- **Gemini**: replace hardcoded `-y` with `--approval-mode` driven by permission config (`yolo`/`auto_edit`/`plan`/`default`)
- **CI**: align with llm-rosetta — upgrade to actions v6, add `ty check`, add install-smoke-test matrix job
- **Code quality**: fix all ruff UP006/UP035 warnings, resolve C901 complexity in `default_run` and `_build_command`

Closes #1, closes #2, closes #3, closes #4

## Test plan

- [x] 147 unit tests pass locally
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `ty check` clean
- [ ] CI passes on GitHub Actions