### PR TITLE
fix: populate message_end text in codex and opencode providers

### DIFF
--- a/src/agentabi/providers/codex_native.py
+++ b/src/agentabi/providers/codex_native.py
@@ -47,6 +47,9 @@ class CodexNativeProvider:
     - turn.completed  — turn ends with usage stats
     """
 
+    def __init__(self) -> None:
+        self._pending_text: list[str] = []
+
     @staticmethod
     def is_available() -> bool:
         """Check if `codex` CLI is available."""
@@ -150,21 +153,20 @@ class CodexNativeProvider:
         cmd.append(task["prompt"])
         return cmd
 
-    @staticmethod
-    def _parse_event(raw: dict[str, Any]) -> list[IREvent]:
+    def _parse_event(self, raw: dict[str, Any]) -> list[IREvent]:
         """Convert a Codex CLI JSONL event to IR events."""
         event_type = raw.get("type")
 
         if event_type == "thread.started":
-            return CodexNativeProvider._handle_thread_started(raw)
+            return self._handle_thread_started(raw)
         elif event_type == "turn.started":
-            return CodexNativeProvider._handle_turn_started()
+            return self._handle_turn_started()
         elif event_type == "item.started":
-            return CodexNativeProvider._handle_item(raw, started=True)
+            return self._handle_item(raw, started=True)
         elif event_type == "item.completed":
-            return CodexNativeProvider._handle_item(raw, started=False)
+            return self._handle_item(raw, started=False)
         elif event_type == "turn.completed":
-            return CodexNativeProvider._handle_turn_completed(raw)
+            return self._handle_turn_completed(raw)
         return []
 
     @staticmethod
@@ -184,8 +186,7 @@ class CodexNativeProvider:
         }
         return [msg_start]
 
-    @staticmethod
-    def _handle_turn_completed(raw: dict[str, Any]) -> list[IREvent]:
+    def _handle_turn_completed(self, raw: dict[str, Any]) -> list[IREvent]:
         results: list[IREvent] = []
 
         usage_raw = raw.get("usage", {})
@@ -208,6 +209,9 @@ class CodexNativeProvider:
         results.append(usage_event)
 
         end: MessageEndEvent = {"type": "message_end", "stop_reason": "end_turn"}
+        if self._pending_text:
+            end["text"] = "".join(self._pending_text)
+            self._pending_text = []
         results.append(end)
 
         session_end: SessionEndEvent = {"type": "session_end"}
@@ -215,20 +219,19 @@ class CodexNativeProvider:
 
         return results
 
-    @staticmethod
-    def _handle_item(raw: dict[str, Any], *, started: bool) -> list[IREvent]:
+    def _handle_item(self, raw: dict[str, Any], *, started: bool) -> list[IREvent]:
         """Convert an item.started or item.completed event to IR events."""
         item = raw.get("item", {})
         item_type = item.get("type", "")
 
         if item_type == "agent_message":
-            return CodexNativeProvider._handle_agent_message(item, started=started)
+            return self._handle_agent_message(item, started=started)
         elif item_type == "command_execution":
-            return CodexNativeProvider._handle_command(item, started=started)
+            return self._handle_command(item, started=started)
         elif item_type == "file_change":
-            return CodexNativeProvider._handle_file_change(item, started=started)
+            return self._handle_file_change(item, started=started)
         elif item_type == "mcp_tool_call":
-            return CodexNativeProvider._handle_mcp_tool(item, started=started)
+            return self._handle_mcp_tool(item, started=started)
         elif item_type == "error":
             if not started:
                 err: ErrorEvent = {
@@ -238,13 +241,15 @@ class CodexNativeProvider:
                 return [err]
         return []
 
-    @staticmethod
-    def _handle_agent_message(item: dict[str, Any], *, started: bool) -> list[IREvent]:
+    def _handle_agent_message(
+        self, item: dict[str, Any], *, started: bool
+    ) -> list[IREvent]:
         if started:
             return []
         text = item.get("text", "")
         if not text:
             return []
+        self._pending_text.append(text)
         delta: MessageDeltaEvent = {
             "type": "message_delta",
             "text": text,

--- a/src/agentabi/providers/codex_sdk.py
+++ b/src/agentabi/providers/codex_sdk.py
@@ -34,6 +34,9 @@ class CodexSDKProvider:
     Requires: pip install agentabi[codex]
     """
 
+    def __init__(self) -> None:
+        self._pending_text: list[str] = []
+
     @staticmethod
     def is_available() -> bool:
         """Check if codex-sdk-python is installed."""
@@ -99,8 +102,7 @@ class CodexSDKProvider:
 
         return await default_run(self, task)
 
-    @staticmethod
-    def _convert(event: Any) -> list[IREvent]:
+    def _convert(self, event: Any) -> list[IREvent]:
         """Convert a codex-sdk ThreadEvent to IR events."""
         from codex_sdk import (
             ItemCompletedEvent,
@@ -113,17 +115,17 @@ class CodexSDKProvider:
         )
 
         if isinstance(event, ThreadStartedEvent):
-            return CodexSDKProvider._convert_thread_started(event)
+            return self._convert_thread_started(event)
         elif isinstance(event, TurnStartedEvent):
-            return CodexSDKProvider._convert_turn_started()
+            return self._convert_turn_started()
         elif isinstance(event, TurnCompletedEvent):
-            return CodexSDKProvider._convert_turn_completed(event)
+            return self._convert_turn_completed(event)
         elif isinstance(event, TurnFailedEvent):
-            return CodexSDKProvider._convert_turn_failed(event)
+            return self._convert_turn_failed(event)
         elif isinstance(event, ItemStartedEvent):
-            return CodexSDKProvider._convert_item(event.item, started=True)
+            return self._convert_item(event.item, started=True)
         elif isinstance(event, ItemCompletedEvent):
-            return CodexSDKProvider._convert_item(event.item, started=False)
+            return self._convert_item(event.item, started=False)
         elif isinstance(event, ThreadErrorEvent):
             err: ErrorEvent = {
                 "type": "error",
@@ -150,8 +152,7 @@ class CodexSDKProvider:
         }
         return [start]
 
-    @staticmethod
-    def _convert_turn_completed(event: Any) -> list[IREvent]:
+    def _convert_turn_completed(self, event: Any) -> list[IREvent]:
         results: list[IREvent] = []
         usage_obj = getattr(event, "usage", None)
         usage: UsageInfo = {}
@@ -169,6 +170,9 @@ class CodexSDKProvider:
         results.append(usage_event)
 
         end: MessageEndEvent = {"type": "message_end", "stop_reason": "end_turn"}
+        if self._pending_text:
+            end["text"] = "".join(self._pending_text)
+            self._pending_text = []
         results.append(end)
 
         session_end: SessionEndEvent = {"type": "session_end"}
@@ -186,8 +190,18 @@ class CodexSDKProvider:
         err: ErrorEvent = {"type": "error", "error": msg, "is_fatal": True}
         return [err]
 
-    @staticmethod
-    def _convert_item(item: Any, *, started: bool) -> list[IREvent]:
+    def _convert_agent_message(self, item: Any) -> list[IREvent]:
+        """Convert an AgentMessageItem completion to IR events."""
+        text = item.text
+        if text:
+            self._pending_text.append(text)
+        delta: MessageDeltaEvent = {
+            "type": "message_delta",
+            "text": text,
+        }
+        return [delta]
+
+    def _convert_item(self, item: Any, *, started: bool) -> list[IREvent]:
         """Convert a ThreadItem to IR events."""
         from codex_sdk import (
             AgentMessageItem,
@@ -199,12 +213,7 @@ class CodexSDKProvider:
 
         if isinstance(item, AgentMessageItem):
             if not started:
-                # Emit text on completion
-                delta: MessageDeltaEvent = {
-                    "type": "message_delta",
-                    "text": item.text,
-                }
-                return [delta]
+                return self._convert_agent_message(item)
         elif isinstance(item, CommandExecutionItem):
             if started:
                 tool_use: ToolUseEvent = {

--- a/src/agentabi/providers/opencode_native.py
+++ b/src/agentabi/providers/opencode_native.py
@@ -38,6 +38,9 @@ class OpenCodeNativeProvider:
     JSON events into IR events.
     """
 
+    def __init__(self) -> None:
+        self._pending_text: list[str] = []
+
     @staticmethod
     def is_available() -> bool:
         """Check if `opencode` CLI is available."""
@@ -131,8 +134,7 @@ class OpenCodeNativeProvider:
         cmd.append(task["prompt"])
         return cmd
 
-    @staticmethod
-    def _parse_event(raw: dict[str, Any]) -> list[IREvent]:
+    def _parse_event(self, raw: dict[str, Any]) -> list[IREvent]:
         """Convert an OpenCode JSON event to IR events.
 
         OpenCode JSON format (--format json):
@@ -146,13 +148,13 @@ class OpenCodeNativeProvider:
         session_id = raw.get("sessionID", "")
 
         if event_type == "step_start":
-            return OpenCodeNativeProvider._handle_step_start(part, session_id)
+            return self._handle_step_start(part, session_id)
         elif event_type == "text":
-            return OpenCodeNativeProvider._handle_text(part)
+            return self._handle_text(part)
         elif event_type == "tool_use":
-            return OpenCodeNativeProvider._handle_tool_use(part)
+            return self._handle_tool_use(part)
         elif event_type == "step_finish":
-            return OpenCodeNativeProvider._handle_step_finish(part, session_id)
+            return self._handle_step_finish(part, session_id)
         return []
 
     @staticmethod
@@ -175,10 +177,10 @@ class OpenCodeNativeProvider:
         results.append(msg_start)
         return results
 
-    @staticmethod
-    def _handle_text(part: dict[str, Any]) -> list[IREvent]:
+    def _handle_text(self, part: dict[str, Any]) -> list[IREvent]:
         text = part.get("text", "")
         if text:
+            self._pending_text.append(text)
             delta: MessageDeltaEvent = {"type": "message_delta", "text": text}
             return [delta]
         return []
@@ -224,8 +226,9 @@ class OpenCodeNativeProvider:
 
         return results
 
-    @staticmethod
-    def _handle_step_finish(part: dict[str, Any], session_id: str) -> list[IREvent]:
+    def _handle_step_finish(
+        self, part: dict[str, Any], session_id: str
+    ) -> list[IREvent]:
         results: list[IREvent] = []
 
         tokens = part.get("tokens", {})
@@ -254,6 +257,9 @@ class OpenCodeNativeProvider:
             "type": "message_end",
             "stop_reason": reason,
         }
+        if self._pending_text:
+            end["text"] = "".join(self._pending_text)
+            self._pending_text = []
         message_id = part.get("messageID", "")
         if message_id:
             end["message_id"] = message_id

--- a/tests/providers/test_codex_native.py
+++ b/tests/providers/test_codex_native.py
@@ -48,9 +48,12 @@ class TestBuildCommand:
 
 
 class TestParseEvent:
+    def setup_method(self):
+        self.provider = CodexNativeProvider()
+
     def test_thread_started(self):
         raw = {"type": "thread.started", "thread_id": "abc-123"}
-        events = CodexNativeProvider._parse_event(raw)
+        events = self.provider._parse_event(raw)
         assert len(events) == 1
         assert events[0]["type"] == "session_start"
         assert events[0]["session_id"] == "abc-123"
@@ -58,7 +61,7 @@ class TestParseEvent:
 
     def test_turn_started(self):
         raw = {"type": "turn.started"}
-        events = CodexNativeProvider._parse_event(raw)
+        events = self.provider._parse_event(raw)
         assert len(events) == 1
         assert events[0]["type"] == "message_start"
         assert events[0]["role"] == "assistant"
@@ -72,7 +75,7 @@ class TestParseEvent:
                 "text": "The answer is 4",
             },
         }
-        events = CodexNativeProvider._parse_event(raw)
+        events = self.provider._parse_event(raw)
         assert len(events) == 1
         assert events[0]["type"] == "message_delta"
         assert events[0]["text"] == "The answer is 4"
@@ -82,7 +85,7 @@ class TestParseEvent:
             "type": "item.started",
             "item": {"id": "item_0", "type": "agent_message", "text": ""},
         }
-        events = CodexNativeProvider._parse_event(raw)
+        events = self.provider._parse_event(raw)
         assert events == []
 
     def test_agent_message_empty_text(self):
@@ -90,7 +93,7 @@ class TestParseEvent:
             "type": "item.completed",
             "item": {"id": "item_0", "type": "agent_message", "text": ""},
         }
-        events = CodexNativeProvider._parse_event(raw)
+        events = self.provider._parse_event(raw)
         assert events == []
 
     def test_command_started(self):
@@ -105,7 +108,7 @@ class TestParseEvent:
                 "status": "in_progress",
             },
         }
-        events = CodexNativeProvider._parse_event(raw)
+        events = self.provider._parse_event(raw)
         assert len(events) == 1
         assert events[0]["type"] == "tool_use"
         assert events[0]["tool_use_id"] == "item_1"
@@ -124,7 +127,7 @@ class TestParseEvent:
                 "status": "completed",
             },
         }
-        events = CodexNativeProvider._parse_event(raw)
+        events = self.provider._parse_event(raw)
         assert len(events) == 1
         assert events[0]["type"] == "tool_result"
         assert events[0]["tool_use_id"] == "item_1"
@@ -143,7 +146,7 @@ class TestParseEvent:
                 "status": "failed",
             },
         }
-        events = CodexNativeProvider._parse_event(raw)
+        events = self.provider._parse_event(raw)
         assert len(events) == 1
         assert events[0]["type"] == "tool_result"
         assert events[0]["is_error"] is True
@@ -161,7 +164,7 @@ class TestParseEvent:
                 ],
             },
         }
-        events = CodexNativeProvider._parse_event(raw)
+        events = self.provider._parse_event(raw)
         assert len(events) == 3
         assert events[0]["type"] == "file_diff"
         assert events[0]["file_path"] == "src/main.py"
@@ -174,7 +177,7 @@ class TestParseEvent:
             "type": "item.started",
             "item": {"id": "item_3", "type": "file_change", "changes": []},
         }
-        events = CodexNativeProvider._parse_event(raw)
+        events = self.provider._parse_event(raw)
         assert events == []
 
     def test_mcp_tool_started(self):
@@ -189,7 +192,7 @@ class TestParseEvent:
                 "status": "in_progress",
             },
         }
-        events = CodexNativeProvider._parse_event(raw)
+        events = self.provider._parse_event(raw)
         assert len(events) == 1
         assert events[0]["type"] == "tool_use"
         assert events[0]["tool_name"] == "mcp:my_server/search"
@@ -207,7 +210,7 @@ class TestParseEvent:
                 "status": "completed",
             },
         }
-        events = CodexNativeProvider._parse_event(raw)
+        events = self.provider._parse_event(raw)
         assert len(events) == 1
         assert events[0]["type"] == "tool_result"
         assert events[0]["tool_use_id"] == "item_4"
@@ -224,7 +227,7 @@ class TestParseEvent:
                 "status": "failed",
             },
         }
-        events = CodexNativeProvider._parse_event(raw)
+        events = self.provider._parse_event(raw)
         assert len(events) == 1
         assert events[0]["is_error"] is True
         assert events[0]["content"] == "not found"
@@ -238,7 +241,7 @@ class TestParseEvent:
                 "message": "Something went wrong",
             },
         }
-        events = CodexNativeProvider._parse_event(raw)
+        events = self.provider._parse_event(raw)
         assert len(events) == 1
         assert events[0]["type"] == "error"
         assert events[0]["error"] == "Something went wrong"
@@ -252,7 +255,7 @@ class TestParseEvent:
                 "output_tokens": 5,
             },
         }
-        events = CodexNativeProvider._parse_event(raw)
+        events = self.provider._parse_event(raw)
         assert len(events) == 3  # usage + message_end + session_end
         assert events[0]["type"] == "usage"
         assert events[0]["usage"]["input_tokens"] == 10849
@@ -271,14 +274,223 @@ class TestParseEvent:
                 "output_tokens": 10,
             },
         }
-        events = CodexNativeProvider._parse_event(raw)
+        events = self.provider._parse_event(raw)
         usage = events[0]["usage"]
         assert usage["cache_read_tokens"] == 50
 
     def test_unknown_event_type(self):
         raw = {"type": "unknown.thing", "data": "whatever"}
-        events = CodexNativeProvider._parse_event(raw)
+        events = self.provider._parse_event(raw)
         assert events == []
+
+    def test_message_end_carries_text(self):
+        """Verify that message_end carries accumulated text from agent_message."""
+        # Simulate: agent_message completed → turn.completed
+        self.provider._parse_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_0",
+                    "type": "agent_message",
+                    "text": "The answer is 18",
+                },
+            }
+        )
+        events = self.provider._parse_event(
+            {
+                "type": "turn.completed",
+                "usage": {
+                    "input_tokens": 100,
+                    "cached_input_tokens": 0,
+                    "output_tokens": 5,
+                },
+            }
+        )
+        end = [e for e in events if e["type"] == "message_end"][0]
+        assert end["text"] == "The answer is 18"
+
+    def test_message_end_accumulates_multiple_messages(self):
+        """Verify text from multiple agent_message items is concatenated."""
+        self.provider._parse_event(
+            {
+                "type": "item.completed",
+                "item": {"id": "item_0", "type": "agent_message", "text": "Hello "},
+            }
+        )
+        self.provider._parse_event(
+            {
+                "type": "item.completed",
+                "item": {"id": "item_1", "type": "agent_message", "text": "world"},
+            }
+        )
+        events = self.provider._parse_event(
+            {
+                "type": "turn.completed",
+                "usage": {
+                    "input_tokens": 10,
+                    "cached_input_tokens": 0,
+                    "output_tokens": 5,
+                },
+            }
+        )
+        end = [e for e in events if e["type"] == "message_end"][0]
+        assert end["text"] == "Hello world"
+
+    def test_message_end_no_text_when_no_agent_message(self):
+        """Verify message_end has no text key when no agent_message was received."""
+        events = self.provider._parse_event(
+            {
+                "type": "turn.completed",
+                "usage": {
+                    "input_tokens": 10,
+                    "cached_input_tokens": 0,
+                    "output_tokens": 5,
+                },
+            }
+        )
+        end = [e for e in events if e["type"] == "message_end"][0]
+        assert "text" not in end
+
+    def test_pending_text_cleared_after_flush(self):
+        """Verify pending text is cleared after turn.completed."""
+        self.provider._parse_event(
+            {
+                "type": "item.completed",
+                "item": {"id": "item_0", "type": "agent_message", "text": "First"},
+            }
+        )
+        self.provider._parse_event(
+            {
+                "type": "turn.completed",
+                "usage": {
+                    "input_tokens": 10,
+                    "cached_input_tokens": 0,
+                    "output_tokens": 5,
+                },
+            }
+        )
+        # Second turn with no text
+        events = self.provider._parse_event(
+            {
+                "type": "turn.completed",
+                "usage": {
+                    "input_tokens": 10,
+                    "cached_input_tokens": 0,
+                    "output_tokens": 5,
+                },
+            }
+        )
+        end = [e for e in events if e["type"] == "message_end"][0]
+        assert "text" not in end
+
+
+class TestResultTextAggregation:
+    """End-to-end test: full event flow through _RunState produces result_text."""
+
+    def test_codex_flow_produces_result_text(self):
+        from agentabi.providers.base import _RunState
+
+        provider = CodexNativeProvider()
+        state = _RunState()
+
+        # Simulate full Codex session: thread.started → turn.started →
+        # agent_message → turn.completed
+        raw_events = [
+            {"type": "thread.started", "thread_id": "thread-abc"},
+            {"type": "turn.started"},
+            {
+                "type": "item.completed",
+                "item": {"id": "item_0", "type": "agent_message", "text": "18"},
+            },
+            {
+                "type": "turn.completed",
+                "usage": {
+                    "input_tokens": 100,
+                    "cached_input_tokens": 0,
+                    "output_tokens": 5,
+                },
+            },
+        ]
+        for raw in raw_events:
+            for event in provider._parse_event(raw):
+                state.handle(event)
+
+        result = state.build()
+        assert result["status"] == "success"
+        assert result["result_text"] == "18"
+
+    def test_codex_multi_turn_produces_result_text(self):
+        """Multi-turn: text → tool → text → done. Final text should win."""
+        from agentabi.providers.base import _RunState
+
+        provider = CodexNativeProvider()
+        state = _RunState()
+
+        raw_events = [
+            {"type": "thread.started", "thread_id": "thread-abc"},
+            # Turn 1: agent says something, then uses a tool
+            {"type": "turn.started"},
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_0",
+                    "type": "agent_message",
+                    "text": "Let me check.",
+                },
+            },
+            {
+                "type": "item.started",
+                "item": {
+                    "id": "item_1",
+                    "type": "command_execution",
+                    "command": "echo 18",
+                },
+            },
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_1",
+                    "type": "command_execution",
+                    "command": "echo 18",
+                    "aggregated_output": "18\n",
+                    "exit_code": 0,
+                    "status": "completed",
+                },
+            },
+            {
+                "type": "turn.completed",
+                "usage": {
+                    "input_tokens": 100,
+                    "cached_input_tokens": 0,
+                    "output_tokens": 50,
+                },
+            },
+            # Turn 2: agent gives final answer
+            {"type": "turn.started"},
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_2",
+                    "type": "agent_message",
+                    "text": "The answer is 18.",
+                },
+            },
+            {
+                "type": "turn.completed",
+                "usage": {
+                    "input_tokens": 200,
+                    "cached_input_tokens": 0,
+                    "output_tokens": 10,
+                },
+            },
+        ]
+        for raw in raw_events:
+            for event in provider._parse_event(raw):
+                state.handle(event)
+
+        result = state.build()
+        assert result["status"] == "success"
+        assert result["result_text"] == "The answer is 18."
 
 
 class TestCapabilities:

--- a/tests/providers/test_codex_sdk.py
+++ b/tests/providers/test_codex_sdk.py
@@ -160,11 +160,16 @@ def _patch_codex_modules():
 class TestCodexSDKConvert:
     """Test _convert() dispatches to correct handler."""
 
-    def _convert(self, event):
+    def setup_method(self):
+        """Create a fresh provider instance for each test."""
         with _patch_codex_modules():
             from agentabi.providers.codex_sdk import CodexSDKProvider
 
-            return CodexSDKProvider._convert(event)
+            self._provider = CodexSDKProvider()
+
+    def _convert(self, event):
+        with _patch_codex_modules():
+            return self._provider._convert(event)
 
     def test_thread_started(self):
         event = MockThreadStartedEvent(thread_id="thread-xyz")
@@ -341,6 +346,38 @@ class TestCodexSDKConvert:
 
         events = self._convert(UnknownEvent())
         assert events == []
+
+    def test_message_end_carries_text(self):
+        """Verify that message_end carries accumulated text from agent_message."""
+        item = MockAgentMessageItem(text="The answer is 18")
+        self._convert(MockItemCompletedEvent(item=item))
+        events = self._convert(
+            MockTurnCompletedEvent(usage=MockUsage(input_tokens=100, output_tokens=5))
+        )
+        end = [e for e in events if e["type"] == "message_end"][0]
+        assert end["text"] == "The answer is 18"
+
+    def test_message_end_no_text_when_no_message(self):
+        """Verify message_end has no text key when no agent_message was received."""
+        events = self._convert(
+            MockTurnCompletedEvent(usage=MockUsage(input_tokens=100, output_tokens=5))
+        )
+        end = [e for e in events if e["type"] == "message_end"][0]
+        assert "text" not in end
+
+    def test_pending_text_cleared_after_flush(self):
+        """Verify pending text is cleared after turn.completed."""
+        item = MockAgentMessageItem(text="First")
+        self._convert(MockItemCompletedEvent(item=item))
+        self._convert(
+            MockTurnCompletedEvent(usage=MockUsage(input_tokens=10, output_tokens=5))
+        )
+        # Second turn with no text
+        events = self._convert(
+            MockTurnCompletedEvent(usage=MockUsage(input_tokens=10, output_tokens=5))
+        )
+        end = [e for e in events if e["type"] == "message_end"][0]
+        assert "text" not in end
 
 
 class TestCodexSDKCapabilities:

--- a/tests/providers/test_opencode_native.py
+++ b/tests/providers/test_opencode_native.py
@@ -77,6 +77,9 @@ class TestBuildCommand:
 
 
 class TestParseEvent:
+    def setup_method(self):
+        self.provider = OpenCodeNativeProvider()
+
     def test_step_start(self):
         raw = {
             "type": "step_start",
@@ -89,7 +92,7 @@ class TestParseEvent:
                 "type": "step-start",
             },
         }
-        events = OpenCodeNativeProvider._parse_event(raw)
+        events = self.provider._parse_event(raw)
         assert len(events) == 2
         assert events[0]["type"] == "session_start"
         assert events[0]["session_id"] == "ses_abc"
@@ -107,7 +110,7 @@ class TestParseEvent:
                 "text": "The answer is 4",
             },
         }
-        events = OpenCodeNativeProvider._parse_event(raw)
+        events = self.provider._parse_event(raw)
         assert len(events) == 1
         assert events[0]["type"] == "message_delta"
         assert events[0]["text"] == "The answer is 4"
@@ -118,7 +121,7 @@ class TestParseEvent:
             "sessionID": "ses_abc",
             "part": {"type": "text", "text": ""},
         }
-        events = OpenCodeNativeProvider._parse_event(raw)
+        events = self.provider._parse_event(raw)
         assert len(events) == 0
 
     def test_tool_use_completed(self):
@@ -137,7 +140,7 @@ class TestParseEvent:
                 },
             },
         }
-        events = OpenCodeNativeProvider._parse_event(raw)
+        events = self.provider._parse_event(raw)
         assert len(events) == 2
         assert events[0]["type"] == "tool_use"
         assert events[0]["tool_use_id"] == "call_123"
@@ -162,7 +165,7 @@ class TestParseEvent:
                 },
             },
         }
-        events = OpenCodeNativeProvider._parse_event(raw)
+        events = self.provider._parse_event(raw)
         assert len(events) == 2
         assert events[0]["type"] == "tool_use"
         assert events[1]["type"] == "tool_result"
@@ -186,7 +189,7 @@ class TestParseEvent:
                 "cost": 0.005,
             },
         }
-        events = OpenCodeNativeProvider._parse_event(raw)
+        events = self.provider._parse_event(raw)
         assert len(events) == 2  # usage + message_end
         assert events[0]["type"] == "usage"
         assert events[0]["usage"]["input_tokens"] == 100
@@ -208,7 +211,7 @@ class TestParseEvent:
                 "cost": 0,
             },
         }
-        events = OpenCodeNativeProvider._parse_event(raw)
+        events = self.provider._parse_event(raw)
         assert len(events) == 3  # usage + message_end + session_end
         assert events[2]["type"] == "session_end"
         assert events[2]["session_id"] == "ses_abc"
@@ -222,14 +225,228 @@ class TestParseEvent:
                 "tokens": {},
             },
         }
-        events = OpenCodeNativeProvider._parse_event(raw)
+        events = self.provider._parse_event(raw)
         types = [e["type"] for e in events]
         assert "session_end" not in types
 
     def test_unknown_event_type(self):
         raw = {"type": "unknown_event", "data": "whatever"}
-        events = OpenCodeNativeProvider._parse_event(raw)
+        events = self.provider._parse_event(raw)
         assert events == []
+
+    def test_message_end_carries_text(self):
+        """Verify that message_end carries accumulated text from text events."""
+        # Simulate: text → step_finish(stop)
+        self.provider._parse_event(
+            {
+                "type": "text",
+                "sessionID": "ses_abc",
+                "part": {"type": "text", "text": "The answer is 18"},
+            }
+        )
+        events = self.provider._parse_event(
+            {
+                "type": "step_finish",
+                "sessionID": "ses_abc",
+                "part": {
+                    "reason": "stop",
+                    "tokens": {"total": 10, "input": 0, "output": 10},
+                    "cost": 0,
+                },
+            }
+        )
+        end = [e for e in events if e["type"] == "message_end"][0]
+        assert end["text"] == "The answer is 18"
+
+    def test_message_end_accumulates_multiple_text_events(self):
+        """Verify text from multiple text events is concatenated."""
+        self.provider._parse_event(
+            {
+                "type": "text",
+                "sessionID": "ses_abc",
+                "part": {"type": "text", "text": "Hello "},
+            }
+        )
+        self.provider._parse_event(
+            {
+                "type": "text",
+                "sessionID": "ses_abc",
+                "part": {"type": "text", "text": "world"},
+            }
+        )
+        events = self.provider._parse_event(
+            {
+                "type": "step_finish",
+                "sessionID": "ses_abc",
+                "part": {
+                    "reason": "stop",
+                    "tokens": {"total": 10, "input": 0, "output": 10},
+                    "cost": 0,
+                },
+            }
+        )
+        end = [e for e in events if e["type"] == "message_end"][0]
+        assert end["text"] == "Hello world"
+
+    def test_message_end_no_text_when_no_text_events(self):
+        """Verify message_end has no text key when no text events were received."""
+        events = self.provider._parse_event(
+            {
+                "type": "step_finish",
+                "sessionID": "ses_abc",
+                "part": {
+                    "reason": "stop",
+                    "tokens": {"total": 10, "input": 0, "output": 10},
+                    "cost": 0,
+                },
+            }
+        )
+        end = [e for e in events if e["type"] == "message_end"][0]
+        assert "text" not in end
+
+    def test_pending_text_cleared_after_flush(self):
+        """Verify pending text is cleared after step_finish."""
+        self.provider._parse_event(
+            {
+                "type": "text",
+                "sessionID": "ses_abc",
+                "part": {"type": "text", "text": "First"},
+            }
+        )
+        self.provider._parse_event(
+            {
+                "type": "step_finish",
+                "sessionID": "ses_abc",
+                "part": {
+                    "reason": "tool-calls",
+                    "tokens": {},
+                },
+            }
+        )
+        # Second step_finish with no text
+        events = self.provider._parse_event(
+            {
+                "type": "step_finish",
+                "sessionID": "ses_abc",
+                "part": {
+                    "reason": "stop",
+                    "tokens": {"total": 10, "input": 0, "output": 10},
+                    "cost": 0,
+                },
+            }
+        )
+        end = [e for e in events if e["type"] == "message_end"][0]
+        assert "text" not in end
+
+
+class TestResultTextAggregation:
+    """End-to-end test: full event flow through _RunState produces result_text."""
+
+    def test_opencode_flow_produces_result_text(self):
+        from agentabi.providers.base import _RunState
+
+        provider = OpenCodeNativeProvider()
+        state = _RunState()
+
+        # Simulate full OpenCode session: step_start → text → step_finish(stop)
+        raw_events = [
+            {
+                "type": "step_start",
+                "sessionID": "ses_abc",
+                "part": {"messageID": "msg_1"},
+            },
+            {
+                "type": "text",
+                "sessionID": "ses_abc",
+                "part": {"type": "text", "text": "18"},
+            },
+            {
+                "type": "step_finish",
+                "sessionID": "ses_abc",
+                "part": {
+                    "reason": "stop",
+                    "tokens": {"total": 10, "input": 0, "output": 10},
+                    "cost": 0,
+                },
+            },
+        ]
+        for raw in raw_events:
+            for event in provider._parse_event(raw):
+                state.handle(event)
+
+        result = state.build()
+        assert result["status"] == "success"
+        assert result["result_text"] == "18"
+
+    def test_opencode_multi_turn_produces_result_text(self):
+        """Multi-turn: text → tool → text → done. Final text should win."""
+        from agentabi.providers.base import _RunState
+
+        provider = OpenCodeNativeProvider()
+        state = _RunState()
+
+        raw_events = [
+            {
+                "type": "step_start",
+                "sessionID": "ses_abc",
+                "part": {"messageID": "msg_1"},
+            },
+            # Turn 1: text then tool-calls
+            {
+                "type": "text",
+                "sessionID": "ses_abc",
+                "part": {"type": "text", "text": "Let me check."},
+            },
+            {
+                "type": "tool_use",
+                "sessionID": "ses_abc",
+                "part": {
+                    "tool": "bash",
+                    "callID": "call_1",
+                    "state": {
+                        "status": "completed",
+                        "input": {"command": "echo 18"},
+                        "output": "18",
+                    },
+                },
+            },
+            {
+                "type": "step_finish",
+                "sessionID": "ses_abc",
+                "part": {
+                    "reason": "tool-calls",
+                    "tokens": {"total": 100, "input": 50, "output": 50},
+                    "cost": 0.001,
+                },
+            },
+            # Turn 2: final answer
+            {
+                "type": "step_start",
+                "sessionID": "ses_abc",
+                "part": {"messageID": "msg_2"},
+            },
+            {
+                "type": "text",
+                "sessionID": "ses_abc",
+                "part": {"type": "text", "text": "The answer is 18."},
+            },
+            {
+                "type": "step_finish",
+                "sessionID": "ses_abc",
+                "part": {
+                    "reason": "stop",
+                    "tokens": {"total": 50, "input": 20, "output": 30},
+                    "cost": 0.001,
+                },
+            },
+        ]
+        for raw in raw_events:
+            for event in provider._parse_event(raw):
+                state.handle(event)
+
+        result = state.build()
+        assert result["status"] == "success"
+        assert result["result_text"] == "The answer is 18."
 
 
 class TestCapabilities:


### PR DESCRIPTION
## Summary

- Codex (native + SDK) and OpenCode providers emitted `message_delta` events but never set `text` on `message_end`, causing `result_text` to be empty on success
- Added instance-level `_pending_text` accumulators to each provider — text from `agent_message` / `text` events is collected and flushed into `message_end["text"]` on turn completion
- Converted affected static methods to instance methods to support the accumulator pattern

## Test plan

- [x] Unit tests for `message_end["text"]` population (single message, multiple messages, cleared after flush, no text)
- [x] End-to-end `_RunState` aggregation tests simulating full Codex/OpenCode session flows (single-turn and multi-turn)
- [x] All 166 unit tests pass, 0 regressions
- [ ] Manual verification with argo-proxy E2E matrix (requires running proxy)

Closes #7